### PR TITLE
Fix wrong sent disconnect payload in TrevorCommon#stop()

### DIFF
--- a/common/src/main/java/tech/tagline/trevor/common/TrevorCommon.java
+++ b/common/src/main/java/tech/tagline/trevor/common/TrevorCommon.java
@@ -10,6 +10,7 @@ import tech.tagline.trevor.api.database.Database;
 import tech.tagline.trevor.api.util.Keys;
 import tech.tagline.trevor.common.proxy.DatabaseProxyImpl;
 import tech.tagline.trevor.api.data.Platform;
+import tech.tagline.trevor.common.util.Protocol;
 
 import java.util.UUID;
 
@@ -61,7 +62,7 @@ public class TrevorCommon implements TrevorAPI {
         connection.getNetworkPlayers().forEach(uuid -> {
           DisconnectPayload payload = connection.destroy(UUID.fromString(uuid));
 
-          connection.publish(Keys.CHANNEL_DATA.of(), gson.toJson(payload));
+          connection.publish(Keys.CHANNEL_DATA.of(), Protocol.serialize(payload, gson));
         });
       }
 


### PR DESCRIPTION
After stopping the proxy, following ClassNotFoundException is thrown:
```
[20:41:52 ERROR]: java.lang.ClassNotFoundException: {"timestamp":1605987712228,"uuid":"***","source":"***"}
[20:41:52 ERROR]: 	at net.md_5.bungee.api.plugin.PluginClassloader.loadClass0(PluginClassloader.java:63)
[20:41:52 ERROR]: 	at net.md_5.bungee.api.plugin.PluginClassloader.loadClass(PluginClassloader.java:37)
[20:41:52 ERROR]: 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
[20:41:52 ERROR]: 	at java.base/java.lang.Class.forName0(Native Method)
[20:41:52 ERROR]: 	at java.base/java.lang.Class.forName(Class.java:315)
[20:41:52 ERROR]: 	at tech.tagline.trevor.common.util.Protocol.deserialize(Protocol.java:16)
[20:41:52 ERROR]: 	at tech.tagline.trevor.common.proxy.DatabaseProxyImpl.onNetworkIntercom(DatabaseProxyImpl.java:77)
[20:41:52 ERROR]: 	at tech.tagline.trevor.common.database.redis.RedisIntercom.lambda$onMessage$1(RedisIntercom.java:65)
[20:41:52 ERROR]: 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[20:41:52 ERROR]: 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[20:41:52 ERROR]: 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
[20:41:52 ERROR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[20:41:52 ERROR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[20:41:52 ERROR]: 	at java.base/java.lang.Thread.run(Thread.java:834)
```

The cause of this problem is a wrong serialization of the DisconnectPayload because the class name is not sent.
I fixed it by using Protocol#serialize instead of sending the JSON output directly.