### PR TITLE
Fixes 'name' in NetworkConnectEvents being null

### DIFF
--- a/common/src/main/java/co/schemati/trevor/common/proxy/DatabaseProxyImpl.java
+++ b/common/src/main/java/co/schemati/trevor/common/proxy/DatabaseProxyImpl.java
@@ -38,7 +38,7 @@ public class DatabaseProxyImpl implements DatabaseProxy {
     return database.open().thenApply(connection -> {
       try {
         if (!connection.isOnline(user)) {
-          ConnectPayload payload = ConnectPayload.of(instance, user.uuid(), user.address());
+          ConnectPayload payload = ConnectPayload.of(instance, user.uuid(), user.name(), user.address());
 
           connection.create(user);
           post(RedisDatabase.CHANNEL_DATA, connection, payload);


### PR DESCRIPTION
`DatabaseProxyImpl` used a deprecated constructor of `ConnectPayload` resulting in player names being null in `NetworkConnectEvent`.

Tested on Velocity v1.1.4. Not tested on Bungee.